### PR TITLE
Fix PageData schema name

### DIFF
--- a/frontend/src/pages/home/atoms/pageDataAtom.ts
+++ b/frontend/src/pages/home/atoms/pageDataAtom.ts
@@ -3,13 +3,13 @@ import { atom } from 'jotai'
 import { paramsSchema } from "../../../hooks/images/useGenerate";
 import { focusAtom } from "jotai-optics";
 
-export const pageDataShcema = z.object({
+export const pageDataSchema = z.object({
     params: paramsSchema,
     prompt_sources: z.array(z.string()),
     preview_width: z.number()
 })
 
-type PageData = z.infer<typeof pageDataShcema>
+type PageData = z.infer<typeof pageDataSchema>
 
 export const pageDataAtom = atom<PageData>({
     params: {


### PR DESCRIPTION
## Summary
- rename `pageDataShcema` to `pageDataSchema`
- reference the new schema name in the `PageData` type

## Testing
- `ruff check ./backend --fix`
- `yarn lint:fix` *(fails: package missing)*
- `pytest` *(fails: ModuleNotFoundError: pytest_asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_683fe9f9493483309b5d2958e176d43e