### PR TITLE
Fix upload request handling

### DIFF
--- a/frontend/src/hooks/images/useUpload.ts
+++ b/frontend/src/hooks/images/useUpload.ts
@@ -20,9 +20,12 @@ const url = 'images/upload'
 export const useUpload = (): UploadFunc => {
 
     const axios = useAxios()
-    return React.useCallback<UploadFunc>(({ file }) =>
-        axios.post(url, { file }, { headers: { 'Content-Type': 'multipart/form-data' } })
-            .then(res => resultSchema.parse(res.data)),
-        [axios])
+    return React.useCallback<UploadFunc>(({ file }) => {
+        const formData = new FormData()
+        formData.append('file', file)
+        return axios.post(url, formData, {
+            headers: { 'Content-Type': 'multipart/form-data' }
+        }).then(res => resultSchema.parse(res.data))
+    }, [axios])
 
 }


### PR DESCRIPTION
## Summary
- update upload hook to send file using FormData

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_683feaea33f88330a01263a5c7ac954f